### PR TITLE
add optional clevis-based unlock support in initrd

### DIFF
--- a/features/clevis/README.md
+++ b/features/clevis/README.md
@@ -1,0 +1,28 @@
+# clevis
+
+The `clevis` feature adds optional support for Clevis-based LUKS unlock in
+initrd.
+
+When this feature is enabled, the `luks` handler tries to unlock a LUKS device
+with Clevis before falling back to the existing interactive passphrase prompt.
+
+If Clevis is not available in the image, or if Clevis-based unlock fails, the
+existing password prompt logic is preserved.
+
+## Requirements
+
+This feature is intended to be used together with the `luks` feature.
+
+A Clevis-enabled LUKS device must be provisioned in advance on the installed
+system, for example with TPM2 binding.
+
+For more information about Clevis see:
+<https://github.com/latchset/clevis>
+
+## Configuration
+
+Enable the feature by adding it to `FEATURES`:
+
+```make
+FEATURES += clevis
+```

--- a/features/clevis/config.mk
+++ b/features/clevis/config.mk
@@ -1,0 +1,1 @@
+$(call feature-requires, luks)

--- a/features/clevis/rules.mk
+++ b/features/clevis/rules.mk
@@ -1,0 +1,15 @@
+PUT_FEATURE_PROGS += \
+    clevis \
+    clevis-decrypt \
+    clevis-decrypt-tpm2 \
+    clevis-luks-unlock \
+    clevis-pin-tpm2 \
+    cryptsetup \
+    jq \
+    jose \
+    tpm2_pcrread \
+    tpm2_getcap
+
+PUT_FEATURE_FILES += /usr/bin/clevis-luks-common-functions
+
+PUT_FEATURE_LIBS += libtss2-tcti-device.so.0

--- a/features/luks/data/lib/uevent/handlers/085-luks
+++ b/features/luks/data/lib/uevent/handlers/085-luks
@@ -349,6 +349,17 @@ handler() {
 		message "The keyfile was not found for partition: $LUKS_ROOT"
 		rc=1
 	fi
+	if command -v clevis >/dev/null 2>&1; then
+		message "Сlevis detected."
+		message "Attempting to decrypt the partition using clevis luks..."
+		if [ "$rc" -ne 0 ] && shell_var_is_no "$luks_headless"; then
+			clevis luks unlock -d "$LUKS_ROOT" -n "$luks_volume"
+			rc="$?"
+		fi
+		if [ "$rc" -ne 0 ]; then
+			message "clevis could not decrypt!"
+		fi
+	fi
 
 	if [ "$rc" -ne 0 ] && shell_var_is_no "$luks_headless"; then
 		if shell_var_is_yes "$luks_empty_password"; then


### PR DESCRIPTION
This PR adds optional clevis support for TPM2-backed LUKS unlock in initrd.

The series introduces a clevis feature and updates the luks handler to try
clevis unlock before falling back to the existing interactive password prompt.

If clevis is not present or unlock fails, the current behavior is preserved.