### PR TITLE
iscsi: replace ISCSI_TARGET_LUN with ISCSI_TARGET_GROUP variable

### DIFF
--- a/features/iscsi/README.md
+++ b/features/iscsi/README.md
@@ -6,7 +6,7 @@ Feature adds you to perform a diskless system boot using pxe and iSCSI.
 - **ISCSI_TARGET_NAME** -- Target name iSCSI, required parameter
 - **ISCSI_TARGET_IP** -- Target IP address iSCSI, required parameter 
 - **ISCSI_TARGET_PORT** -- Target port iSCSI 
-- **ISCSI_TARGET_LUN** -- Target group tag iSCSI
+- **ISCSI_TARGET_GROUP** -- Target group tag iSCSI
 - **ISCSI_INITIATOR** -- Initiator name iSCSI
 - **ISCSI_USERNAME** -- Username for initiator authentication by the target(s)
 - **ISCSI_PASSWORD** -- Password for initiator authentication by the target(s) 

--- a/features/iscsi/data/etc/initrd/cmdline.d/iscsi
+++ b/features/iscsi/data/etc/initrd/cmdline.d/iscsi
@@ -1,7 +1,7 @@
 register_parameter string ISCSI_TARGET_NAME
 register_parameter string ISCSI_TARGET_IP
 register_parameter number ISCSI_TARGET_PORT
-register_parameter number ISCSI_TARGET_LUN
+register_parameter number ISCSI_TARGET_GROUP
 register_parameter string ISCSI_INITIATOR
 register_parameter string ISCSI_USERNAME
 register_parameter string ISCSI_PASSWORD


### PR DESCRIPTION
The ISCSI_TARGET_LUN parameter is missing from the iscsi script and iscsistart arguments. Instead, ISCSI_TARGET_GROUP should be used, but it is currently missing from register_parameter (it is present only in the iscsi script). As a result, these parameters do not work.