### PR TITLE
feature usb-storage: drop the removed 'ub' driver, detect UAS

### DIFF
--- a/features/usb-storage/README.md
+++ b/features/usb-storage/README.md
@@ -3,6 +3,4 @@
 Feature adds autodetection support for block devices backed by USB storage.
 
 The guess logic checks whether the detected device is driven by `usb-storage`
-and, if so, requests that kernel module. When `CONFIG_USB_LIBUSUAL=y` is present
-in the kernel config, this helps pull in the USB mass-storage stack for the root
-device.
+and, if so, requests that kernel module for the image.

--- a/features/usb-storage/README.md
+++ b/features/usb-storage/README.md
@@ -2,7 +2,7 @@
 
 Feature adds autodetection support for block devices backed by USB storage.
 
-The guess logic checks whether the detected device is driven by `ub` or
-`usb-storage` and, if so, requests both kernel modules. When
-`CONFIG_USB_LIBUSUAL=y` is present in the kernel config, this helps pull in the
-USB mass-storage stack for the root device.
+The guess logic checks whether the detected device is driven by `usb-storage`
+and, if so, requests that kernel module. When `CONFIG_USB_LIBUSUAL=y` is present
+in the kernel config, this helps pull in the USB mass-storage stack for the root
+device.

--- a/features/usb-storage/README.md
+++ b/features/usb-storage/README.md
@@ -3,4 +3,5 @@
 Feature adds autodetection support for block devices backed by USB storage.
 
 The guess logic checks whether the detected device is driven by `usb-storage`
-and, if so, requests that kernel module for the image.
+or by `uas` (USB Attached SCSI) and, if so, requests that kernel module for the
+image.

--- a/features/usb-storage/guess/device
+++ b/features/usb-storage/guess/device
@@ -1,11 +1,6 @@
 #!/bin/bash -efu
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-if [ -s "$KERNEL_CONFIG" ]; then
-	grep -qs '^[[:space:]]*CONFIG_USB_LIBUSUAL=y' "$KERNEL_CONFIG" ||
-		exit 0
-fi
-
 found=
 if [ -f "$SYSFS_PATH/$1"/uevent ]; then
 	! grep -qs '^DRIVER=usb-storage$' "$SYSFS_PATH/$1"/uevent ||

--- a/features/usb-storage/guess/device
+++ b/features/usb-storage/guess/device
@@ -1,23 +1,22 @@
 #!/bin/bash -efu
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-found=
+driver=
 if [ -f "$SYSFS_PATH/$1"/uevent ]; then
-	! grep -qs '^DRIVER=usb-storage$' "$SYSFS_PATH/$1"/uevent ||
-		found=1
+	driver="$(sed -n -e 's/^DRIVER=\(uas\|usb-storage\)$/\1/p' "$SYSFS_PATH/$1"/uevent)"
 fi
 
-if [ -z "$found" ] && [ -e "$SYSFS_PATH/$1"/driver ]; then
+if [ -z "$driver" ] && [ -e "$SYSFS_PATH/$1"/driver ]; then
 	t="$(readlink -ev "$SYSFS_PATH/$1"/driver 2>/dev/null)" ||:
 	case "${t##*/}" in
-		usb-storage) found=1
+		uas|usb-storage) driver="${t##*/}"
 			;;
 	esac
 fi
 
-[ -n "$found" ] ||
+[ -n "$driver" ] ||
 	exit 0
 
 . guess-functions
 
-guess_module usb-storage
+guess_module "$driver"

--- a/features/usb-storage/guess/device
+++ b/features/usb-storage/guess/device
@@ -8,14 +8,14 @@ fi
 
 found=
 if [ -f "$SYSFS_PATH/$1"/uevent ]; then
-	! grep -E -qs '^DRIVER=(ub|usb-storage)$' "$SYSFS_PATH/$1"/uevent ||
+	! grep -qs '^DRIVER=usb-storage$' "$SYSFS_PATH/$1"/uevent ||
 		found=1
 fi
 
 if [ -z "$found" ] && [ -e "$SYSFS_PATH/$1"/driver ]; then
 	t="$(readlink -ev "$SYSFS_PATH/$1"/driver 2>/dev/null)" ||:
 	case "${t##*/}" in
-		ub|usb-storage) found=1
+		usb-storage) found=1
 			;;
 	esac
 fi
@@ -25,5 +25,4 @@ fi
 
 . guess-functions
 
-guess_module ub
 guess_module usb-storage

--- a/features/usb-storage/tests/ts0001-guess-device-light/expect
+++ b/features/usb-storage/tests/ts0001-guess-device-light/expect
@@ -1,4 +1,3 @@
 guess:modules
-ub
 usb-storage
 rc=0

--- a/features/usb-storage/tests/ts0003-guess-device-light-uas/expect
+++ b/features/usb-storage/tests/ts0003-guess-device-light-uas/expect
@@ -1,0 +1,3 @@
+guess:modules
+uas
+rc=0

--- a/features/usb-storage/tests/ts0003-guess-device-light-uas/run
+++ b/features/usb-storage/tests/ts0003-guess-device-light-uas/run
@@ -1,0 +1,15 @@
+#!/bin/bash -efu
+
+cwd="${0%/*}"
+
+. "$cwd"/../../../../testing/tests/guess-feature-sh-functions
+
+guess_feature_test_init "$0"
+
+mkdir -p -- "$SYSFS_PATH/devices/test-usb"
+cat > "$SYSFS_PATH/devices/test-usb/uevent" <<-'EOF'
+DRIVER=uas
+EOF
+
+features/usb-storage/guess/device devices/test-usb
+guess_feature_test_dump

--- a/features/usb-storage/tests/ts0004-guess-device-light-driver-link/expect
+++ b/features/usb-storage/tests/ts0004-guess-device-light-driver-link/expect
@@ -1,0 +1,3 @@
+guess:modules
+usb-storage
+rc=0

--- a/features/usb-storage/tests/ts0004-guess-device-light-driver-link/run
+++ b/features/usb-storage/tests/ts0004-guess-device-light-driver-link/run
@@ -1,0 +1,19 @@
+#!/bin/bash -efu
+
+cwd="${0%/*}"
+
+. "$cwd"/../../../../testing/tests/guess-feature-sh-functions
+
+guess_feature_test_init "$0"
+
+mkdir -p -- "$SYSFS_PATH/devices/test-usb"
+mkdir -p -- "$SYSFS_PATH/bus/usb/drivers/usb-storage"
+
+cat > "$SYSFS_PATH/devices/test-usb/uevent" <<-'EOF'
+SUBSYSTEM=usb
+EOF
+
+ln -s -- "$SYSFS_PATH/bus/usb/drivers/usb-storage" "$SYSFS_PATH/devices/test-usb/driver"
+
+features/usb-storage/guess/device devices/test-usb
+guess_feature_test_dump

--- a/features/usb-storage/tests/ts0005-guess-device-light-driver-link-uas/expect
+++ b/features/usb-storage/tests/ts0005-guess-device-light-driver-link-uas/expect
@@ -1,0 +1,3 @@
+guess:modules
+uas
+rc=0

--- a/features/usb-storage/tests/ts0005-guess-device-light-driver-link-uas/run
+++ b/features/usb-storage/tests/ts0005-guess-device-light-driver-link-uas/run
@@ -1,0 +1,19 @@
+#!/bin/bash -efu
+
+cwd="${0%/*}"
+
+. "$cwd"/../../../../testing/tests/guess-feature-sh-functions
+
+guess_feature_test_init "$0"
+
+mkdir -p -- "$SYSFS_PATH/devices/test-usb"
+mkdir -p -- "$SYSFS_PATH/bus/usb/drivers/uas"
+
+cat > "$SYSFS_PATH/devices/test-usb/uevent" <<-'EOF'
+SUBSYSTEM=usb
+EOF
+
+ln -s -- "$SYSFS_PATH/bus/usb/drivers/uas" "$SYSFS_PATH/devices/test-usb/driver"
+
+features/usb-storage/guess/device devices/test-usb
+guess_feature_test_dump


### PR DESCRIPTION
### Problem

`features/usb-storage/guess/device` unconditionally requests the `ub` kernel
module. The `ub` driver (`drivers/block/ub.c`, "Low Performance USB Block
driver") was deprecated in v3.4 and removed in v3.7, so on any kernel released
in the last decade image generation dies as soon as a USB storage device is
detected:

depinfo: ERROR: Module ub not found.
make[2]: *** [features/add-modules/rules.mk:6: put-modules] Error 1

The only reason this is not hit constantly is the `CONFIG_USB_LIBUSUAL=y` check
at the top of the script. That symbol was removed together with `ub`, so on a
modern kernel the check never matches and the whole detector exits 0 before it
even looks at the device. When `KERNEL_CONFIG` is not available — which
make-initrd reports as a warning, not an error — the check is skipped and the
build breaks instead.

So the feature currently has exactly two states: a no-op, or a build failure.
It was hit in the wild by a distro image builder that runs `make-initrd` with
`--bootdir` pointing into the image tree, where no kernel config is present,
on a host whose swap lives on a USB disk.

Kernel facts, for the record:

| symbol | last kernel version containing it |
| --- | --- |
| `CONFIG_BLK_DEV_UB` | v3.6 ([v3.6](https://github.com/torvalds/linux/blob/v3.6/drivers/block/Kconfig), gone in [v3.7](https://github.com/torvalds/linux/blob/v3.7/drivers/block/Kconfig)) |
| `CONFIG_USB_LIBUSUAL` | v3.6 ([v3.6](https://github.com/torvalds/linux/blob/v3.6/drivers/usb/storage/Kconfig), gone in [v3.7](https://github.com/torvalds/linux/blob/v3.7/drivers/usb/storage/Kconfig)) |

### What this series does

1. **Drop the removed 'ub' kernel module** — the actual fix for the build
failure. Self-contained: it can be applied alone.
2. **Drop the dead CONFIG_USB_LIBUSUAL check** — with `ub` gone, the check has
nothing left to arbitrate, and it is what silently disabled the detector on
every modern kernel. This is a behaviour change: `usb-storage` is now
requested when the device is actually bound to it.
3. **Detect UAS backed devices** — modern USB mass storage is commonly driven
by `uas`, which the detector did not know about at all. The script now
requests the module the device is really bound to. `uas` depends on
`usb-storage` in `modules.dep`, so the latter is pulled in by the normal
dependency resolution.
4. **Cover the driver symlink fallback in tests** — the `driver/` symlink path
(used when the uevent file has no `DRIVER=`) had no test coverage.

### Testing

env PATH="$PWD/tools:$PATH" ./testing/tests/run features/usb-storage/tests
shellcheck -s bash -e <exclude list from Makefile.in> features/usb-storage/guess/device

Both pass on every commit of the series, not only on its tip. The test suite for
this feature grows from 2 to 5 tests; the new symlink tests were verified to
actually catch a regression injected into the fallback path.

### Note for the maintainer

Commit 1 is the bug fix and stands on its own — if commits 2–4 need discussion,
they can be dropped without losing it.